### PR TITLE
Remove `new_website` from deployable branches

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -2,7 +2,7 @@ name: "Deploy website"
 
 on:
   push:
-    branches: [ master, "new_website" ]
+    branches: [ master ]
 
 jobs:
   deploy_website:


### PR DESCRIPTION
The `new_website` branch is only listed while working on the new website. Now that it has been merged in the `dev-new-site`, there's no need to keep it listed there.